### PR TITLE
Grey out towers that can't be bought

### DIFF
--- a/main.py
+++ b/main.py
@@ -280,7 +280,7 @@ class Game:
         for projectile in self.projectiles:
             self.screen.blit(self.camera.apply_image(projectile.image), self.camera.apply_rect(projectile.rect))
 
-        if self.current_tower != None and self.protein >= TOWER_DATA[self.current_tower][0]["upgrade_cost"]:
+        if self.current_tower != None:
             self.draw_tower_preview()
 
         self.screen.blit(self.camera.apply_image(self.map_objects), self.camera.apply_rect(self.map_rect))
@@ -382,6 +382,8 @@ class Game:
 
                 elif self.ui.active:
                     for i, tower_rect in enumerate(self.ui.tower_rects):
+                        if (self.protein < TOWER_DATA[self.available_towers[i]][0]["upgrade_cost"]):
+                            continue
                         temp_rect = tower_rect.copy()
                         temp_rect.x += self.screen.get_size()[0] - self.ui.width
                         if temp_rect.collidepoint(event.pos):
@@ -400,9 +402,6 @@ class Game:
                     return
 
                 if self.map.change_node(x_coord, y_coord, 1) == False:
-                    return
-
-                if self.protein < TOWER_DATA[self.current_tower][0]["upgrade_cost"]:
                     return
                 
                 path = self.pathfinder.astar(tile_map, ((tile_from_xcoords(self.starts[0].x, self.map.tilesize),

--- a/ui.py
+++ b/ui.py
@@ -57,6 +57,8 @@ class UI:
         for i, tower in enumerate(self.game.available_towers):
             tower_img = pg.transform.scale(TOWER_DATA[tower][0]["base_image"], self.tower_rects[i].size)
             tower_img.blit(pg.transform.scale(TOWER_DATA[tower][0]["gun_image"], self.tower_rects[i].size), (0, 0))
+            if (self.game.protein < TOWER_DATA[tower][0]["upgrade_cost"]):
+                tower_img.fill(DARKGREY, None, pg.BLEND_RGB_MULT)
             ui.blit(tower_img, self.tower_rects[i])
             temp_rect = self.tower_rects[i].copy()
             temp_rect.x += self.tower_size + self.offset


### PR DESCRIPTION
If the player has insufficient protein to buy a tower, it is not greyed out. This removes the need to check protein when displaying the tower or placing it as well. Closes #28.