### PR TITLE
Optimized Level Select Menu

### DIFF
--- a/data/game.py
+++ b/data/game.py
@@ -406,10 +406,10 @@ class Game(Display):
                     enemy.recreate_path()
 
             elif event.button == 4:
-                self.camera.zoom(0.05)
+                self.camera.zoom(ZOOM_AMT_GAME)
 
             elif event.button == 5:
-                self.camera.zoom(-0.05)
+                self.camera.zoom(-ZOOM_AMT_GAME)
 
         elif (event.type == pg.KEYDOWN and event.key == pg.K_ESCAPE):
             return "pause"

--- a/data/settings.py
+++ b/data/settings.py
@@ -17,7 +17,8 @@ def resource_path(relative_path):
 LIVES = 5
 PROTEIN = 50
               
-ZOOM_AMOUNT = 0.05
+ZOOM_AMT_GAME = 0.05
+ZOOM_AMT_MENU = 0.1
 
 # define some colors (R, G, B)
 WHITE = pg.Color(255, 255, 255)
@@ -132,7 +133,7 @@ PATH_CORNER4_IMG = pg.image.load(path.join(PATH_IMG_FOLDER, "corner4.png"))
 # load other images
 START_SCREEN_IMG = pg.image.load(path.join(IMG_FOLDER, "start_screen.png"))
 LEVEL_BUTTON_IMG = pg.image.load(path.join(IMG_FOLDER, "level_button.png"))
-BODY_IMG = pg.transform.scale(pg.image.load(path.join(IMG_FOLDER, "body.png")), (2560, 3480))
+BODY_IMG = pg.transform.scale(pg.image.load(path.join(IMG_FOLDER, "body.png")), (1920, 2610))
 
 # load game over images
 RESTART_BTN_IMGS = [[None, None], [None, None]]

--- a/data/tilemap.py
+++ b/data/tilemap.py
@@ -137,7 +137,7 @@ class Camera():
 
     def zoom(self, amount):
         if (amount > 0 and self.current_zoom >= self.minzoom * 4 or amount < 0 and self.current_zoom <= self.minzoom):
-            return
+            return False
 
         self.current_zoom += amount
 
@@ -146,3 +146,6 @@ class Camera():
 
     def move(self, x, y):
         self.camera = self.camera.move(x, y)
+        
+    def get_zoom(self):
+        return self.current_zoom


### PR DESCRIPTION
Fixes #108. The game now either loads the transformed body images beforehand (high zoom levels) or only transforms it when changing zoom. I also made the BODY_IMG smaller and reduced the zoom amount for the menu.

Overall, loading time should be negligible, the scrolling in Level Select Menu should be smooth even at high zoom levels, and the memory usage of the program should still be <200 MB