### PR TITLE
Improved Tower Select Menu to show tower info

### DIFF
--- a/data/dev_tools.py
+++ b/data/dev_tools.py
@@ -540,7 +540,7 @@ class DevUI():
                 width = attr_surf.get_width()
             surf_list.append(attr_surf)
 
-        font = pg.font.Font(FONT, round(MENU_TEXT_SIZE * 1.5))
+        font = pg.font.Font(FONT, round(MENU_TEXT_SIZE * 1.2))
         save_text = font.render("Save Settings", 1, WHITE)
         save_button = pg.transform.scale(LEVEL_BUTTON_IMG, (
         round(save_text.get_rect().width * 1.5), save_text.get_height())).copy().convert_alpha()
@@ -704,7 +704,7 @@ class Attribute():
         self.change_val(value)
 
     def draw(self):
-        font = pg.font.Font(FONT, round(MENU_TEXT_SIZE * 1.5))
+        font = pg.font.Font(FONT, round(MENU_TEXT_SIZE * 1.2))
         surf_list = []
         if self.type == "string":
             if self.current_value == "":

--- a/data/settings.py
+++ b/data/settings.py
@@ -60,7 +60,8 @@ GAME_STOP_AUD_FOLDER = path.join(AUDIO_FOLDER, "game_stop")
 
 # UI Constants
 MENU_OFFSET = 10
-MENU_TEXT_SIZE = 25
+MENU_OFFSET_2 = 5
+MENU_TEXT_SIZE = 30
 
 # TowerSelectMenu Constants
 NUM_ALLOWED = 2


### PR DESCRIPTION
Fixes #114. Also made the MENU_TEXT_SIZE a bit bigger (from 25 to 30) so that the level/tower infos are easier to read.

I'll defer on adding tower descriptions for now since it'll require updating the level preview and it's also awkward to store in tower.json. One way is to make the first element in each tower's list a dictionary that stores the attributes that remain the same across all stages (e.g. descriptions). We can also change each tower's data from a list to a dictionary with the stage data stored under the key "stage".