### PR TITLE
Optimized pathfinding and drawing of tower preview

### DIFF
--- a/data/pathfinding.py
+++ b/data/pathfinding.py
@@ -67,12 +67,21 @@ class Pathfinder():
                         data.append(current)
                         current = came_from[current]
                     data.append(current)
+                    
                     self.map[0][start[0][0]][start[0][1]] = prevstate
                     if ignore_towers:
                         self.map[0] = temp_map
-                        self.flying_paths[start] = data
-                    else:
-                        self.paths[start] = data
+                        
+                    for i, node in enumerate(data): # Adds the path for each node in the path
+                        # this only has to be done until a node that already has a path is reached
+                        if ignore_towers:
+                            if self.flying_paths.get(node, False) != False:
+                                break
+                            self.flying_paths[node] = data[i:]
+                        else:
+                            if self.paths.get(node, False) != False:
+                                break
+                            self.paths[node] = data[i:]
                     return data.copy()
 
                 close_set.add(current)

--- a/data/towers.py
+++ b/data/towers.py
@@ -119,7 +119,7 @@ class Tower(Obstacle):
                         hit.damage(self.damage)
                         if self.slow_speed != 1:
                             hits[0].slow(self.slow_speed, self.slow_duration)
-                    self.sound.play()
+                    TOWER_DATA[self.name]["stages"][self.stage]["shoot_sound"].play()
                     self.next_spawn = pg.time.get_ticks() + self.attack_speed * 1000
 
             elif self.current_enemy != None:


### PR DESCRIPTION
Sort of addresses #139, though the optimizations implemented weren't the ones suggested in there. Main changes were:
- After finishing the pathfinding, the program now stores the path of all the nodes in the path instead of just the start node.
- The program will only do the above for nodes that don't have a path stored yet.
- Tower previews now only run the pathfinding algorithm when it's being drawn over a tile in the path.
- Also fixed a bug where the game would crash when trying to play the neutrophil sound.

I'm not too familiar with the pathfinding code so you might want to check out the changes to make sure I didn't mess anything up.