### PR TITLE
Made a new tutorial level and improved textbox implementation

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -2,7 +2,7 @@
     "common_cold": {
         "explode_on_death": false,
         "flying": false,
-        "hp": 5,
+        "hp": 8,
         "protein": 1,
         "shield": false,
         "mutate": false,
@@ -22,7 +22,7 @@
     "hepatitis_a": {
         "explode_on_death": false,
         "flying": false,
-        "hp": 15,
+        "hp": 20,
         "protein": 2,
         "shield": false,
         "mutate": false,
@@ -32,7 +32,7 @@
     "hepatitis_b": {
         "explode_on_death": false,
         "flying": false,
-        "hp": 20,
+        "hp": 25,
         "protein": 3,
         "shield": true,
         "shield_hp": 5,

--- a/data/game.py
+++ b/data/game.py
@@ -150,7 +150,7 @@ class Game(Display):
         self.camera = Camera(SCREEN_WIDTH, SCREEN_HEIGHT, self.map.width, self.map.height)
         self.pathfinder.clear_nodes(self.map.get_map())
         self.textbox = Textbox(self)
-        self.prepare_next_wave()
+        self.prepare_next_text()
         self.draw_tower_bases_wrapper()
         self.make_stripped_path_wrapper()
 
@@ -190,9 +190,9 @@ class Game(Display):
                 self.start_next_wave()
 
         if self.current_wave_done() and self.in_a_wave:
-            if self.wave < self.max_wave - 1:
-                self.prepare_next_wave()                
-            elif len(self.enemies) == 0:
+            if self.wave < self.max_wave:
+                self.prepare_next_text()
+            if len(self.enemies) == 0:
                 pg.event.post(self.game_done_event)
 
     def current_wave_done(self):
@@ -201,35 +201,36 @@ class Game(Display):
                 return False
         return True
     
-    def prepare_next_wave(self):
+    def prepare_next_text(self):
         self.wave += 1
-        if self.wave >= len(self.level_data["waves"]):
-            return
-
-        elif isinstance(self.level_data["waves"][self.wave][0], str):
+        if len(self.level_data["texts"][self.wave]) > 0:
             self.text = True
-            self.texts = self.level_data["waves"][self.wave].copy()
+            self.texts = self.level_data["texts"][self.wave].copy()
             self.ui.set_next_wave_btn(False)
             self.textbox.set_text(self.texts[0])
             self.textbox.finish_text()
             self.textbox.yoffset = self.textbox.rect.height
             self.textbox.toggle(True)
-
         else:
-            print(self.wave)
             self.text = False
             self.textbox.enabled = False
-            self.in_a_wave = False
-            self.ui.set_next_wave_btn(True)
-            self.time_passed = 0
+            self.prepare_next_wave()
+        
+    def prepare_next_wave(self):
+        if self.wave == self.max_wave:
+            return
+        
+        self.in_a_wave = False
+        self.ui.set_next_wave_btn(True)
+        self.time_passed = 0
+        
+        self.starts.clear()
+        for i in self.level_data["waves"][self.wave]:
+            self.starts.append(
+                Start(self, i["start"], i["enemy_type"], i["enemy_count"],
+                        i["spawn_delay"], i["spawn_rate"]))
 
-            self.starts.clear()
-            for i in self.level_data["waves"][self.wave]:
-                self.starts.append(
-                    Start(self, i["start"], i["enemy_type"], i["enemy_count"],
-                          i["spawn_delay"], i["spawn_rate"]))
-
-            self.make_stripped_path_wrapper()
+        self.make_stripped_path_wrapper()
 
     def start_next_wave(self):
         self.in_a_wave = True

--- a/data/game_misc.py
+++ b/data/game_misc.py
@@ -7,11 +7,7 @@ class UI:
         self.width = width
         self.offset = offset
         self.wave = 1
-        self.dialogues = []
-        for i, wave in enumerate(self.game.level_data["waves"]):
-            if isinstance(wave[0], str):
-                self.dialogues.append(i)
-        self.max_wave = game.max_wave - len(self.dialogues)
+        self.max_wave = game.max_wave
         self.lives = game.lives
         self.protein = game.protein
         
@@ -42,12 +38,9 @@ class UI:
         self.next_wave_btn_changed = True
 
     def update(self):
-        if (self.lives != self.game.lives or self.protein != self.game.protein or self.next_wave_btn_changed):
+        if (self.lives != self.game.lives or self.protein != self.game.protein or self.next_wave_btn_changed or self.wave != self.game.wave):
             self.next_wave_btn_changed = False
-            i = 0
-            while i < len(self.dialogues) and self.dialogues[i] < self.wave:
-                i += 1
-            self.wave = max(self.game.wave - len(self.dialogues[:i + 1]), 0)
+            self.wave = self.game.wave
             self.lives = self.game.lives
             self.protein = self.game.protein
             self.ui = self.get_ui()

--- a/data/levels/level0.json
+++ b/data/levels/level0.json
@@ -1,66 +1,88 @@
 {
-    "title": "Testing Ground",
-    "description": "A place to test out the game. Relax and code on!",
+    "title": "The First Invasion",
+    "description": "A tutorial to help ease you into the mechanics of the game.",
     "difficulty": 0,
     "body_part": 0,
-    "waves": [
+    "texts": [
         [
             "Hello there newbie! Nice to have you on board!",
             "You'll be in charge of our defensive tactics now, since the old commander left.",
-            "It looks like some enemies will be attacking! Place a tower down to defend the body!",
-            "Hint: You can place a tower down by clicking on its icon and clicking again where you want to place it.",
-            "Hint: When you're ready, press the \"Start Wave\" button to let the viruses in."
-        ],
-        [
-            {
-                "start": 0,
-                "enemy_type": "common_cold",
-                "enemy_count": 21,
-                "spawn_delay": 3,
-                "spawn_rate": 0.2,
-                "scroll_position": 1,
-                "tower_name": 0,
-                "tower_stage": 0
-            }
+            "It looks like some enemies will be attacking! Place towers down to defend the body!",
+            "You can place a tower down by clicking on its icon then clicking on the tile where you want to place it.",
+            "When you're ready, press the \"Start Wave\" button to let the viruses in.",
+            "Hint: You can hinder enemies by placing towers on their path, forcing them to take a longer one to the goal."
         ],
         [
             "Good stuff! With you in charge, these viruses will be shredded to smithereens in no time!",
             "Uh oh. More of them incoming. Place more towers down!"
         ],
         [
+            "That should keep them out for a brief moement!",
+            "Use this downtime now to add more towers or upgrade existing ones.",
+            "To upgrade a tower, select it and click Upgrade. Make sure you have enough protein!"
+        ],
+        [
+            "Looks like you've got the hang of things! Only one more wave to go!",
+            "Hint: If you're unhappy with your current tower setup, click on a tower and click sell to remove it from the map.",
+            "You'll even earn back half the protein you spent on it!"
+        ],
+        [
+            "Looks like that was the last of them for now. A brilliant outcome for your first mission!"
+        ]
+    ],
+    "waves": [
+        [
+            {
+                "start": 0,
+                "enemy_type": "common_cold",
+                "enemy_count": 20,
+                "spawn_delay": 3,
+                "spawn_rate": 0.4,
+                "scroll_position": 1,
+                "tower_name": 0,
+                "tower_stage": 0
+            }
+        ],
+        [
             {
                 "start": 0,
                 "enemy_type": "hepatitis_a",
-                "enemy_count": 10,
+                "enemy_count": 8,
                 "spawn_delay": 3,
-                "spawn_rate": 0.6
+                "spawn_rate": 0.8
             },
             {
                 "start": 0,
                 "enemy_type": "common_cold",
-                "enemy_count": 16,
+                "enemy_count": 20,
                 "spawn_delay": 3,
+                "spawn_rate": 0.4
+            }
+        ],
+        [
+            {
+                "start": 0,
+                "enemy_type": "hepatitis_a",
+                "enemy_count": 15,
+                "spawn_delay": 3,
+                "spawn_rate": 0.7
+            },
+            {
+                "start": 0,
+                "enemy_type": "common_cold",
+                "enemy_count": 30,
+                "spawn_delay": 4,
                 "spawn_rate": 0.3
             }
         ],
         [
             {
                 "start": 0,
-                "enemy_type": "coronavirus",
-                "enemy_count": 5,
-                "spawn_delay": 3,
-                "spawn_rate": 1
-            },
-            {
-                "start": 0,
-                "enemy_type": "common_cold",
-                "enemy_count": 20,
+                "enemy_type": "hepatitis_a",
+                "enemy_count": 40,
                 "spawn_delay": 4,
-                "spawn_rate": 0.2
+                "spawn_rate": 0.3
             }
-        ],
-        [
-            "Looks like that was the last of them for now. A brilliant outcome for your first mission!"
         ]
     ]
 }

--- a/data/levels/level1.json
+++ b/data/levels/level1.json
@@ -3,6 +3,13 @@
     "description": "Another place to try out things. Maybe it will be different on this map!",
     "difficulty": 2,
     "body_part": 1,
+    "texts": [
+        [],
+        [],
+        [],
+        [],
+        []
+    ],
     "waves": [
         [
             {

--- a/data/levels/level2.json
+++ b/data/levels/level2.json
@@ -3,6 +3,12 @@
     "description": "Extreme testing ground! Prepare to die!",
     "difficulty": 4,
     "body_part": 3,
+    "texts": [
+        [],
+        [],
+        [],
+        []
+    ],
     "waves": [
         [
             {

--- a/data/levels/level3.json
+++ b/data/levels/level3.json
@@ -3,6 +3,11 @@
     "description": "Manage two different paths this time with some scary enemies!",
     "difficulty": 3,
     "body_part": 2,
+    "texts": [
+        [],
+        [],
+        []
+    ],
     "waves": [
         [
             {

--- a/data/maps/mouth.tmx
+++ b/data/maps/mouth.tmx
@@ -1,114 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.2" tiledversion="1.3.3" orientation="orthogonal" renderorder="right-down" width="16" height="12" tilewidth="42" tileheight="42" infinite="0" nextlayerid="11" nextobjectid="68">
+<map version="1.2" tiledversion="1.3.3" orientation="orthogonal" renderorder="right-down" width="16" height="12" tilewidth="42" tileheight="42" infinite="0" nextlayerid="4" nextobjectid="16">
  <tileset firstgid="1" source="body_tiles.tsx"/>
- <tileset firstgid="49" source="artery_and_vein.tsx"/>
- <tileset firstgid="89" source="start_and_goal.tsx"/>
+ <tileset firstgid="49" source="start_and_goal.tsx"/>
  <layer id="1" name="background" width="16" height="12">
   <data encoding="csv">
-38,42,42,42,42,42,42,42,42,42,42,42,42,42,42,2,
-30,1,1,1,1,1,1,1,1,1,1,1,1,1,1,9,
-30,1,36,1,1,1,1,1,1,1,1,1,1,1,1,1,
-30,1,8,20,48,1,1,1,1,1,1,1,1,1,1,21,
-30,1,7,45,1,1,1,1,1,1,1,1,1,1,1,6,
-30,1,12,1,1,1,1,1,1,1,1,1,1,1,1,6,
-30,1,1,1,1,1,1,1,1,1,1,1,1,1,1,6,
-30,1,1,1,1,1,1,1,1,1,1,1,1,1,1,6,
-30,1,1,1,1,1,1,1,1,1,1,1,1,36,1,6,
-45,1,1,1,1,1,1,1,1,24,41,41,41,46,1,6,
-1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,6,
-18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,14
-</data>
- </layer>
- <layer id="8" name="veins" width="16" height="12">
-  <data encoding="csv">
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,83,74,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,82,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,82,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,82,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,82,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,82,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,82,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,54,63,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
-</data>
- </layer>
- <layer id="7" name="arteries" width="16" height="12">
-  <data encoding="csv">
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,50,52,52,52,52,52,51,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,62,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,62,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,62,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,62,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,71,70,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+13,13,13,13,13,13,38,42,42,42,42,42,42,42,42,2,
+13,13,13,13,38,42,45,1,1,1,1,1,1,1,1,6,
+13,13,38,42,45,1,1,1,1,1,1,1,1,1,1,6,
+38,42,45,1,1,1,1,1,1,1,1,1,1,1,1,6,
+45,1,1,1,1,1,1,1,1,1,1,1,1,1,1,9,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+33,1,1,1,1,1,1,1,1,1,1,1,1,1,1,21,
+26,18,33,1,1,1,1,1,1,1,1,1,1,1,1,6,
+13,13,26,18,33,1,1,1,1,1,1,1,1,1,1,6,
+13,13,13,13,26,18,33,1,1,1,1,1,1,1,1,6,
+13,13,13,13,13,13,26,18,18,18,18,18,18,18,18,14
 </data>
  </layer>
  <layer id="2" name="foreground" width="16" height="12">
   <data encoding="csv">
 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,96,
-0,0,0,0,0,0,0,0,0,0,0,75,0,0,0,0,
-0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-0,0,0,0,0,49,0,0,0,0,0,0,0,0,0,0,
 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+52,0,0,0,0,0,0,0,0,0,0,0,0,0,0,56,
+58,0,0,0,0,0,0,0,0,0,0,0,0,0,0,56,
 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-93,0,0,0,0,0,0,0,0,55,0,0,69,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 </data>
  </layer>
- <objectgroup id="4" name="obstacles">
-  <object id="27" name="start0" x="0" y="420" width="42" height="42"/>
-  <object id="36" name="goal" x="630" y="84" width="42.5" height="42.5"/>
-  <object id="37" name="wall" x="0" y="462" width="672" height="42"/>
-  <object id="38" name="wall" x="630" y="126" width="42" height="336"/>
-  <object id="39" name="wall" x="0" y="0" width="42" height="420"/>
-  <object id="40" name="wall" x="42" y="0" width="630" height="42"/>
-  <object id="41" name="wall" x="84" y="84" width="42" height="168"/>
-  <object id="42" name="wall" x="126" y="126" width="42" height="84"/>
-  <object id="43" name="wall" x="168" y="126" width="42" height="42"/>
-  <object id="44" name="wall" x="378" y="378" width="210" height="42"/>
-  <object id="45" name="wall" x="546" y="336" width="42" height="42"/>
-  <object id="46" name="wall" x="630" y="42" width="42" height="42"/>
-  <object id="51" name="artery" x="210" y="210" width="294" height="42"/>
-  <object id="52" name="artery" x="462" y="252" width="42" height="210"/>
-  <object id="53" name="artery" x="504" y="420" width="42" height="42"/>
-  <object id="54" name="vein" x="378" y="420" width="84" height="42"/>
-  <object id="55" name="vein" x="420" y="126" width="42" height="294"/>
-  <object id="56" name="vein" x="462" y="126" width="42" height="42"/>
-  <object id="59" name="artery_entrance" x="168" y="210" width="84" height="42">
-   <properties>
-    <property name="positive" value="false"/>
-   </properties>
-  </object>
-  <object id="60" name="artery_entrance" x="504" y="420" width="84" height="42">
-   <properties>
-    <property name="positive" value="true"/>
-   </properties>
-  </object>
-  <object id="61" name="vein_entrance" x="336" y="420" width="84" height="42">
-   <properties>
-    <property name="positive" value="false"/>
-   </properties>
-  </object>
-  <object id="62" name="vein_entrance" x="462" y="126" width="84" height="42">
-   <properties>
-    <property name="positive" value="true"/>
-   </properties>
-  </object>
-  <object id="64" name="wall" x="210" y="210" width="42" height="42"/>
-  <object id="65" name="wall" x="378" y="420" width="42" height="42"/>
-  <object id="66" name="wall" x="504" y="420" width="42" height="42"/>
-  <object id="67" name="wall" x="462" y="126" width="42" height="42"/>
+ <objectgroup id="3" name="obstacles">
+  <object id="1" name="wall" x="0" y="0" width="672" height="42"/>
+  <object id="2" name="wall" x="0" y="42" width="294" height="42"/>
+  <object id="3" name="wall" x="0" y="84" width="210" height="42"/>
+  <object id="4" name="wall" x="0" y="126" width="126" height="42"/>
+  <object id="5" name="wall" x="0" y="168" width="42" height="42"/>
+  <object id="6" name="wall" x="0" y="294" width="42" height="42"/>
+  <object id="7" name="wall" x="0" y="336" width="126" height="42"/>
+  <object id="8" name="wall" x="0" y="378" width="210" height="42"/>
+  <object id="9" name="wall" x="0" y="420" width="294" height="42"/>
+  <object id="10" name="wall" x="0" y="462" width="672" height="42"/>
+  <object id="11" name="wall" x="630" y="294" width="42" height="168"/>
+  <object id="12" name="wall" x="630" y="42" width="42" height="168"/>
+  <object id="14" name="start0" x="0" y="210" width="42" height="84"/>
+  <object id="15" name="goal" x="630" y="210" width="42" height="84"/>
  </objectgroup>
 </map>

--- a/data/maps/stomach.tmx
+++ b/data/maps/stomach.tmx
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.2" tiledversion="1.3.3" orientation="orthogonal" renderorder="right-down" width="16" height="12" tilewidth="42" tileheight="42" infinite="0" nextlayerid="11" nextobjectid="68">
+ <tileset firstgid="1" source="body_tiles.tsx"/>
+ <tileset firstgid="49" source="artery_and_vein.tsx"/>
+ <tileset firstgid="89" source="start_and_goal.tsx"/>
+ <layer id="1" name="background" width="16" height="12">
+  <data encoding="csv">
+38,42,42,42,42,42,42,42,42,42,42,42,42,42,42,2,
+30,1,1,1,1,1,1,1,1,1,1,1,1,1,1,9,
+30,1,36,1,1,1,1,1,1,1,1,1,1,1,1,1,
+30,1,8,20,48,1,1,1,1,1,1,1,1,1,1,21,
+30,1,7,45,1,1,1,1,1,1,1,1,1,1,1,6,
+30,1,12,1,1,1,1,1,1,1,1,1,1,1,1,6,
+30,1,1,1,1,1,1,1,1,1,1,1,1,1,1,6,
+30,1,1,1,1,1,1,1,1,1,1,1,1,1,1,6,
+30,1,1,1,1,1,1,1,1,1,1,1,1,36,1,6,
+45,1,1,1,1,1,1,1,1,24,41,41,41,46,1,6,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,6,
+18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,14
+</data>
+ </layer>
+ <layer id="8" name="veins" width="16" height="12">
+  <data encoding="csv">
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,83,74,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,82,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,82,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,82,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,82,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,82,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,82,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,54,63,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+</data>
+ </layer>
+ <layer id="7" name="arteries" width="16" height="12">
+  <data encoding="csv">
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,50,52,52,52,52,52,51,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,62,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,62,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,62,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,62,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,71,70,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+</data>
+ </layer>
+ <layer id="2" name="foreground" width="16" height="12">
+  <data encoding="csv">
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,96,
+0,0,0,0,0,0,0,0,0,0,0,75,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,49,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+93,0,0,0,0,0,0,0,0,55,0,0,69,0,0,0,
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+</data>
+ </layer>
+ <objectgroup id="4" name="obstacles">
+  <object id="27" name="start0" x="0" y="420" width="42" height="42"/>
+  <object id="36" name="goal" x="630" y="84" width="42.5" height="42.5"/>
+  <object id="37" name="wall" x="0" y="462" width="672" height="42"/>
+  <object id="38" name="wall" x="630" y="126" width="42" height="336"/>
+  <object id="39" name="wall" x="0" y="0" width="42" height="420"/>
+  <object id="40" name="wall" x="42" y="0" width="630" height="42"/>
+  <object id="41" name="wall" x="84" y="84" width="42" height="168"/>
+  <object id="42" name="wall" x="126" y="126" width="42" height="84"/>
+  <object id="43" name="wall" x="168" y="126" width="42" height="42"/>
+  <object id="44" name="wall" x="378" y="378" width="210" height="42"/>
+  <object id="45" name="wall" x="546" y="336" width="42" height="42"/>
+  <object id="46" name="wall" x="630" y="42" width="42" height="42"/>
+  <object id="51" name="artery" x="210" y="210" width="294" height="42"/>
+  <object id="52" name="artery" x="462" y="252" width="42" height="210"/>
+  <object id="53" name="artery" x="504" y="420" width="42" height="42"/>
+  <object id="54" name="vein" x="378" y="420" width="84" height="42"/>
+  <object id="55" name="vein" x="420" y="126" width="42" height="294"/>
+  <object id="56" name="vein" x="462" y="126" width="42" height="42"/>
+  <object id="59" name="artery_entrance" x="168" y="210" width="84" height="42">
+   <properties>
+    <property name="positive" value="false"/>
+   </properties>
+  </object>
+  <object id="60" name="artery_entrance" x="504" y="420" width="84" height="42">
+   <properties>
+    <property name="positive" value="true"/>
+   </properties>
+  </object>
+  <object id="61" name="vein_entrance" x="336" y="420" width="84" height="42">
+   <properties>
+    <property name="positive" value="false"/>
+   </properties>
+  </object>
+  <object id="62" name="vein_entrance" x="462" y="126" width="84" height="42">
+   <properties>
+    <property name="positive" value="true"/>
+   </properties>
+  </object>
+  <object id="64" name="wall" x="210" y="210" width="42" height="42"/>
+  <object id="65" name="wall" x="378" y="420" width="42" height="42"/>
+  <object id="66" name="wall" x="504" y="420" width="42" height="42"/>
+  <object id="67" name="wall" x="462" y="126" width="42" height="42"/>
+ </objectgroup>
+</map>

--- a/data/save.json
+++ b/data/save.json
@@ -1,12 +1,13 @@
 {
-    "level": 1,
+    "level": 2,
     "music_vol": 0.0,
     "sfx_vol": 0.0,
     "fullscreen": false,
-    "max_dna": 52,
+    "max_dna": 123,
     "used_dna": 0,
     "highscores": [
-        52,
+        106,
+        17,
         0
     ],
     "owned_towers": [
@@ -22,7 +23,7 @@
             "description": "The number of lives you start with on each level."
         },
         "starting_protein": {
-            "value": 50,
+            "value": 30,
             "increment": 5,
             "upgrade_cost": 75,
             "cost_increment": 10,

--- a/data/towers.json
+++ b/data/towers.json
@@ -131,12 +131,12 @@
                 "slow_duration": 3,
                 "slow_speed": 0.5,
                 "tracking": true,
-                "upgrade_cost": 20,
+                "upgrade_cost": 10,
                 "explode_on_impact": false
             },
             {
                 "area_of_effect": false,
-                "attack_speed": 0.7,
+                "attack_speed": 0.6,
                 "bullet_lifetime": 0.5,
                 "bullet_speed": 1250,
                 "damage": 0,
@@ -145,10 +145,10 @@
                 "range": 150,
                 "rotating": true,
                 "rotation_speed": 360,
-                "slow_duration": 3,
+                "slow_duration": 4.0,
                 "slow_speed": 0.5,
                 "tracking": true,
-                "upgrade_cost": 20,
+                "upgrade_cost": 10,
                 "explode_on_impact": false
             },
             {


### PR DESCRIPTION
There's now a new tutorial map for the mouth with the level data adjusted to be suitable for a tutorial level. The textbox implementation was also changed to make them cleaner and easier to work with. Now they are stored separately from the wave data, and if a wave has a textbox associated with it, the textbox won't appear until all the enemies in the previous wave are dead (instead of just finished spawning). This change fixes #205 and #206. 

Other balance changes:
- Old mouth map got changed to the stomach.
- All stages of the goblet cells are now cheaper, stage 2 has improved attack speed and slow duration
- Common cold HP increased to 8, Hepatitis A HP increased to 20, and Hepatitis B HP increased to 25. This was done specifically for the tutorial but it probably makes later levels much more difficult.
- Starting protein lowered to 30.