### PR TITLE
Differentiate tower and enemy explosions

### DIFF
--- a/data/attributes.json
+++ b/data/attributes.json
@@ -243,7 +243,7 @@
         "explode_on_impact": {
             "type": "bool",
             "default": false,
-            "ignore_if_false": ["explosion_radius"]
+            "ignore_if_false": ["explosion_radius", "explosion_color"]
         },
         "explosion_radius": {
             "type": "float",
@@ -252,6 +252,11 @@
             "increment": 25,
             "dp": -1,
             "default": 250
+        },
+        "explosion_color": {
+            "type": "select",
+            "values": ["red","orange","yellow","green","cyan","blue","purple","pink"],
+            "default": 2
         }
     },
     "level": {

--- a/data/dev_tools.py
+++ b/data/dev_tools.py
@@ -186,18 +186,21 @@ class DevClass(Game):
                 rotated_image = pg.transform.rotate(tower.gun_image, math.degrees(tower.rotation))
                 new_rect = rotated_image.get_rect(center=tower.rect.center)
                 surface.blit(rotated_image, new_rect)
-            tower_range_img = pg.Surface((tower.true_range * 2, tower.true_range * 2)).convert_alpha()
-            tower_range_img.fill(BLANK)
-            pg.draw.circle(tower_range_img, HALF_WHITE, (tower.true_range, tower.true_range), tower.true_range)
-            surface.blit((tower_range_img), tower_range_img.get_rect(center=tower.rect.center))
 
         for projectile in self.projectiles:
             surface.blit(projectile.image, projectile.rect)
 
-        surface.blit(self.aoe_surf, (0, 0))
-
         for explosion in self.explosions:
             surface.blit(explosion.get_surf(), (explosion.x, explosion.y))
+
+        surface.blit(self.aoe_surf, (0, 0))
+
+        for tower in self.towers:
+            if not tower.area_of_effect:
+                tower_range_img = pg.Surface((tower.true_range * 2, tower.true_range * 2)).convert_alpha()
+                tower_range_img.fill(BLANK)
+                pg.draw.circle(tower_range_img, HALF_WHITE, (tower.true_range, tower.true_range), tower.true_range)
+                surface.blit((tower_range_img), tower_range_img.get_rect(center=tower.rect.center))
 
         surf = pg.Surface((SCREEN_WIDTH, SCREEN_HEIGHT))
         surf.blit(self.camera.apply_image((surface)), (0, 0))

--- a/data/game_misc.py
+++ b/data/game_misc.py
@@ -265,13 +265,14 @@ class Textbox(pg.Surface):
         self.finish_text()
 
 class Explosion(pg.sprite.Sprite):
-    def __init__(self, game, x, y, rad):
+    def __init__(self, game, x, y, rad, color = 0):
         super().__init__(game.explosions)
         self.clock = game.clock
         self.x = x - rad / 2
         self.y = y - rad / 2
         self.rad = rad
         self.state = 0
+        self.color = AURA_COLORS[color]
         self.surf = pg.Surface((rad, rad)).convert_alpha()
 
     def update(self):
@@ -280,7 +281,7 @@ class Explosion(pg.sprite.Sprite):
         if self.state >= 1:
             self.kill()
         else:
-            self.surf.fill((255, 0, 0, 127 * self.state))
+            self.surf.fill(pg.Color(self.color.r, self.color.g, self.color.b, round(127 * self.state)))
 
     def get_surf(self):
         return self.surf

--- a/data/menus.py
+++ b/data/menus.py
@@ -107,7 +107,10 @@ class Menu(Display):
                 self.blit(self.camera.apply_image(grey_image), self.camera.apply_rect(button))
                 #self.blit(self.camera.apply_image(LOCK_IMG), self.camera.apply_rect(LOCK_IMG.get_rect(center=button.center)))
 
-        self.blit(self.camera.apply_image(LEVEL_BUTTON_IMG), self.camera.apply_rect(self.tower_preview_button))
+        if len(SAVE_DATA["seen_enemies"]) == 0:
+            self.blit(self.camera.apply_image(DARK_LEVEL_BUTTON_IMG), self.camera.apply_rect(self.tower_preview_button))
+        else:
+            self.blit(self.camera.apply_image(LEVEL_BUTTON_IMG), self.camera.apply_rect(self.tower_preview_button))
         lives_text = lives_font.render("Tower", 1, WHITE)
         self.blit(self.camera.apply_image(lives_text), self.camera.apply_tuple(
             (self.tower_preview_button.center[0] - lives_text.get_rect().center[0],
@@ -213,8 +216,9 @@ class Menu(Display):
             if event.button == 1:
                 mouse_pos = self.camera.correct_mouse(pg.mouse.get_pos())
                 if self.tower_preview_button.collidepoint(mouse_pos):
-                    BTN_SFX.play()
-                    return "tower_preview"
+                    if len(SAVE_DATA["seen_enemies"]) > 0:
+                        BTN_SFX.play()
+                        return "tower_preview"
                 elif self.enemy_preview_button.collidepoint(mouse_pos):
                     if len(SAVE_DATA["seen_enemies"]) > 0:
                         BTN_SFX.play()

--- a/data/save.json
+++ b/data/save.json
@@ -16,9 +16,11 @@
         0
     ],
     "owned_towers": [
-        "t_cell"
+        "m_cell"
     ],
-    "seen_enemies": [],
+    "seen_enemies": [
+        "common_cold"
+    ],
     "game_attrs": {
         "lives": {
             "value": 5,

--- a/data/towers.json
+++ b/data/towers.json
@@ -292,7 +292,8 @@
                 "rotation_speed": 10,
                 "tracking": true,
                 "explode_on_impact": true,
-                "explosion_radius": 50
+                "explosion_radius": 50,
+                "explosion_color": 2
             },
             {
                 "damage": 7,
@@ -310,7 +311,8 @@
                 "rotation_speed": 10,
                 "tracking": true,
                 "explode_on_impact": true,
-                "explosion_radius": 75
+                "explosion_radius": 75,
+                "explosion_color": 2
             },
             {
                 "damage": 10,
@@ -328,7 +330,8 @@
                 "rotation_speed": 10,
                 "tracking": true,
                 "explode_on_impact": true,
-                "explosion_radius": 100
+                "explosion_radius": 100,
+                "explosion_color": 2
             }
         ]
     },

--- a/data/towers.py
+++ b/data/towers.py
@@ -130,7 +130,8 @@ class TrackingProjectile(Projectile):
 class ExplodingProjectile(Projectile):
     def __init__(self, args):
         Projectile.__init__(self, args[:-1])
-        self.explosion_radius = args[-1]
+        self.explosion_radius = args[-2]
+        self.explosion_color = args[-1]
 
     def check_for_impact(self):
         hits = pg.sprite.spritecollide(self, self.game.enemies, False)
@@ -139,7 +140,7 @@ class ExplodingProjectile(Projectile):
             self.rect.width = self.rect.height = self.explosion_radius
             self.rect.center = center
             hits = pg.sprite.spritecollide(self, self.game.enemies, False)
-            Explosion(self.game, self.rect.center[0], self.rect.center[1], self.explosion_radius)
+            Explosion(self.game, self.rect.center[0], self.rect.center[1], self.explosion_radius, self.explosion_color)
             for hit in hits:
                 self.tower.hits += 1
                 if hit.damage(self.damage, self.shield_damage):
@@ -150,8 +151,9 @@ class ExplodingProjectile(Projectile):
 
 class TrackingExplodingProjectile(TrackingProjectile, ExplodingProjectile):
     def __init__(self, args):
-        TrackingProjectile.__init__(self, args[:-1])
-        self.explosion_radius = args[-1]
+        TrackingProjectile.__init__(self, args[:-2])
+        self.explosion_radius = args[-2]
+        self.explosion_color = args[-1]
 
 class Tower(Obstacle):
     def __init__(self, game, x, y, name):
@@ -212,6 +214,7 @@ class Tower(Obstacle):
             self.explode_on_impact = data["explode_on_impact"]
             if self.explode_on_impact:
                 self.explosion_radius = data["explosion_radius"]
+                self.explosion_color = data["explosion_color"]
                 
         if load_attack_attrs:
             self.slow_speed = data["slow_speed"]
@@ -293,7 +296,7 @@ class Tower(Obstacle):
                         if self.tracking:
                             if self.explode_on_impact:
                                 TrackingExplodingProjectile([self.game, self, self.rect.centerx, self.rect.centery, self.bullet_image, self.bullet_speed,
-                                       self.bullet_lifetime, self.slow_speed, self.slow_duration, rotation, self.true_damage, self.true_shield_damage, self.rotation_speed, self.true_range, self.current_enemy, self.explosion_radius])
+                                       self.bullet_lifetime, self.slow_speed, self.slow_duration, rotation, self.true_damage, self.true_shield_damage, self.rotation_speed, self.true_range, self.current_enemy, self.explosion_radius, self.explosion_color])
                             else:
                                 TrackingProjectile([self.game, self, self.rect.centerx, self.rect.centery, self.bullet_image, self.bullet_speed,
                                        self.bullet_lifetime, self.slow_speed, self.slow_duration, rotation, self.true_damage, self.true_shield_damage, self.rotation_speed, self.true_range, self.current_enemy])
@@ -301,7 +304,7 @@ class Tower(Obstacle):
                         else:
                             if self.explode_on_impact:
                                 ExplodingProjectile([self.game, self, self.rect.centerx, self.rect.centery, self.bullet_image, self.bullet_speed,
-                                       self.bullet_lifetime, self.slow_speed, self.slow_duration, rotation, self.true_damage, self.true_shield_damage, self.rotation_speed, self.true_range, self.current_enemy, self.explosion_radius])
+                                       self.bullet_lifetime, self.slow_speed, self.slow_duration, rotation, self.true_damage, self.true_shield_damage, self.rotation_speed, self.true_range, self.current_enemy, self.explosion_radius, self.explosion_color])
                             else:
                                 Projectile([self.game, self, self.rect.centerx, self.rect.centery, self.bullet_image, self.bullet_speed, self.bullet_lifetime, self.slow_speed, self.slow_duration, rotation, self.true_damage, self.true_shield_damage])
 


### PR DESCRIPTION
This adds an attribute to towers that shoot exploding bullets which controls the color of their explosions. Fixes #174. 