### PR TITLE
Add a acute mouth level

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -2,7 +2,7 @@
     "common_cold": {
         "explode_on_death": false,
         "flying": false,
-        "hp": 8,
+        "hp": 10,
         "protein": 1,
         "shield": false,
         "mutate": false,
@@ -26,7 +26,7 @@
         "protein": 2,
         "shield": false,
         "mutate": false,
-        "speed": 110,
+        "speed": 125,
         "description": "A very average virus. Has medium health and moves at medium speed."
     },
     "hepatitis_b": {

--- a/data/enemies.py
+++ b/data/enemies.py
@@ -2,6 +2,7 @@ from data.settings import *
 import random
 from data.tilemap import tile_from_coords
 from data.game_misc import Explosion
+import math
 
 class Enemy(pg.sprite.Sprite):
     def __init__(self, game, x, y, name):
@@ -37,8 +38,9 @@ class Enemy(pg.sprite.Sprite):
             prev_scale = 1 # if it's a new enemy (not from mutation), leave image_size as is
             
         data = ENEMY_DATA[self.name]
-        difficulty = 1 + self.game.wave * 0.1
-        self.hp = round(data["hp"] * difficulty)
+        wave_difficulty = 1 + self.game.wave * 0.1
+        game_difficulty = self.game.difficulty * 0.5 + 0.5
+        self.hp = round(data["hp"] * wave_difficulty * game_difficulty)
         print(self.hp)
         self.speed = data["speed"]
         self.dropped_protein = data["protein"]
@@ -47,7 +49,7 @@ class Enemy(pg.sprite.Sprite):
         self.flying = data["flying"]
         self.shield = data["shield"]
         if self.shield:
-            self.shield_max_hp = round(data["shield_hp"] * difficulty)
+            self.shield_max_hp = round(data["shield_hp"] * wave_difficulty * game_difficulty)
             self.shield_hp = self.shield_max_hp
             self.shield_max_recharge_delay = data["shield_recharge_delay"]
             self.shield_recharge_rate = data["shield_recharge_rate"]
@@ -145,7 +147,7 @@ class Enemy(pg.sprite.Sprite):
         if self.hp < 0:
             return None
 
-        hp_surf = pg.Surface((self.hp * 2, 5))
+        hp_surf = pg.Surface((math.ceil(math.log10(self.hp) * 10), 5))
         if self.is_slowed():
             hp_surf.fill(RED)
         else:
@@ -154,9 +156,9 @@ class Enemy(pg.sprite.Sprite):
         if not self.shield:
             return hp_surf
 
-        shield_surf = pg.Surface((self.shield_hp * 2, 5))
+        shield_surf = pg.Surface((math.ceil(math.log10(self.shield_hp) * 10), 5))
         shield_surf.fill(CYAN)
-        combo_surf = pg.Surface((max(self.shield_hp, self.hp) * 2, 10)).convert_alpha()
+        combo_surf = pg.Surface((max(shield_surf.get_width(), hp_surf.get_width()), 10)).convert_alpha()
         combo_surf.fill((0, 0, 0, 0))
         combo_surf.blit(hp_surf, hp_surf.get_rect(center=(combo_surf.get_rect().center[0], 7)))
         combo_surf.blit(shield_surf, shield_surf.get_rect(center=(combo_surf.get_rect().center[0], 2)))

--- a/data/enemies.py
+++ b/data/enemies.py
@@ -37,7 +37,9 @@ class Enemy(pg.sprite.Sprite):
             prev_scale = 1 # if it's a new enemy (not from mutation), leave image_size as is
             
         data = ENEMY_DATA[self.name]
-        self.hp = data["hp"]
+        difficulty = 1 + self.game.wave * 0.1
+        self.hp = round(data["hp"] * difficulty)
+        print(self.hp)
         self.speed = data["speed"]
         self.dropped_protein = data["protein"]
         self.original_image = data["image"]
@@ -45,8 +47,8 @@ class Enemy(pg.sprite.Sprite):
         self.flying = data["flying"]
         self.shield = data["shield"]
         if self.shield:
-            self.shield_max_hp = data["shield_hp"]
-            self.shield_hp = data["shield_hp"]
+            self.shield_max_hp = round(data["shield_hp"] * difficulty)
+            self.shield_hp = self.shield_max_hp
             self.shield_max_recharge_delay = data["shield_recharge_delay"]
             self.shield_recharge_rate = data["shield_recharge_rate"]
 

--- a/data/game.py
+++ b/data/game.py
@@ -235,23 +235,23 @@ class Game(Display):
     def prepare_next_text(self):
         # Wave has text --> text (and the next wave) don't appear until previous wave is all dead
         # Wave has no text --> next wave starts counting down immediately after previous wave is done spawning
-        if not SAVE_DATA["skip_text"] and len(self.level_data["texts"][self.difficulty][self.wave + 1]) > 0:  
+        if not SAVE_DATA["skip_text"] and len(self.level_data["texts"][self.difficulty][self.wave + 1]) > 0:
             if len(self.enemies) == 0:
-                self.wave += 1
                 self.text = True
-                self.texts = self.level_data["texts"][self.difficulty][self.wave].copy()
+                self.texts = self.level_data["texts"][self.difficulty][self.wave + 1].copy()
                 self.ui.set_next_wave_btn(False)
                 self.textbox.set_text(self.texts[0])
                 self.textbox.finish_text()
                 self.textbox.yoffset = self.textbox.rect.height
                 self.textbox.toggle(True)
         else:
-            self.wave += 1
             self.text = False
             self.textbox.enabled = False
             self.prepare_next_wave()
 
     def prepare_next_wave(self):
+        self.wave += 1
+
         if self.wave == self.max_wave:
             return
 

--- a/data/game.py
+++ b/data/game.py
@@ -153,7 +153,7 @@ class Game(Display):
                 for y in range(tile_from_xcoords(start.height, self.map.tilesize)):
                     self.map.set_valid_tower_tile(tile_from_xcoords(start.x, self.map.tilesize) + x, tile_from_xcoords(start.y, self.map.tilesize) + y, 0)
 
-        self.ui = UI(self, 200, 10)
+        self.ui = UI(self, 10)
         self.pathfinder = Pathfinder(
             arteries = arteries,
             artery_entrances = artery_entrances,
@@ -572,12 +572,12 @@ class Game(Display):
                             for enemy in self.enemies:
                                 enemy.recreate_path()
                             for stage in range(tower_dat[1] + 1):
-                                self.protein += round(TOWER_DATA[tower_dat[0]]["stages"][stage]["upgrade_cost"] / 2)
+                                self.protein += round(TOWER_DATA[tower_dat[0]]["stages"][stage]["upgrade_cost"] * (1 + self.difficulty * 0.25) / 2)
                             BUY_SFX.play()
                             self.ui.deselect_tower()
 
                         elif result == "upgrade":
-                            if self.protein >= TOWER_DATA[self.ui.tower.name]["stages"][self.ui.tower.stage + 1]["upgrade_cost"]:
+                            if self.protein >= round(TOWER_DATA[self.ui.tower.name]["stages"][self.ui.tower.stage + 1]["upgrade_cost"] * (1 + self.difficulty * 0.25)):
                                 self.map.upgrade_tower(tower_coords[0], tower_coords[1])
                                 self.draw_tower_bases(self)
                                 BUY_SFX.play()
@@ -587,7 +587,7 @@ class Game(Display):
                         return -1
 
                     elif result > -1:
-                        if self.protein < TOWER_DATA[self.available_towers[result]]["stages"][0]["upgrade_cost"]:
+                        if self.protein < round(TOWER_DATA[self.available_towers[result]]["stages"][0]["upgrade_cost"] * (1 + self.difficulty * 0.25)):
                             WRONG_SELECTION_SFX.play()
                             self.current_tower = None
                         else:
@@ -608,7 +608,7 @@ class Game(Display):
                     self.ui.select_tower(x_coord, y_coord)
                     return -1
 
-                if self.protein < TOWER_DATA[self.current_tower]["stages"][0]["upgrade_cost"]:
+                if self.protein < round(TOWER_DATA[self.current_tower]["stages"][0]["upgrade_cost"] * (1 + 0.25 * self.difficulty)):
                     return -1
 
                 if self.map.is_valid_tower_tile(x_coord, y_coord) == 0 or \
@@ -635,7 +635,7 @@ class Game(Display):
                         for y in range(tile_from_xcoords(start.height, self.map.tilesize)):
                             self.map.set_valid_tower_tile(tile_from_xcoords(start.x, self.map.tilesize) + x,
                                                           tile_from_xcoords(start.y, self.map.tilesize) + y, 0)
-                self.protein -= TOWER_DATA[self.current_tower]["stages"][0]["upgrade_cost"]
+                self.protein -= round(TOWER_DATA[self.current_tower]["stages"][0]["upgrade_cost"] * (1 + self.difficulty * 0.25))
                 self.current_tower = None
 
                 BUY_SFX.play()

--- a/data/game_misc.py
+++ b/data/game_misc.py
@@ -2,11 +2,10 @@ from data.settings import *
 import textwrap
 
 class UI:
-    def __init__(self, game, width, offset):
+    def __init__(self, game, offset):
         self.game = game
-        self.width = width
         self.offset = offset
-        self.wave = 1
+        self.wave = 0
         self.max_wave = game.max_wave
         self.lives = game.lives
         self.protein = game.protein
@@ -15,8 +14,8 @@ class UI:
         self.next_wave_btn_changed = False
         self.active = True
         
-        self.tower_size = round((width - 2 * offset) / 2)
-        self.tower_rects = [pg.Rect(self.offset, self.offset * 6 + HEART_IMG.get_size()[0] * 3 + i * (self.offset + self.tower_size), self.tower_size, self.tower_size) for i, tower in enumerate(self.game.available_towers)]
+        self.tower_size = round(9 * offset)
+        self.tower_rects = [pg.Rect(self.offset, self.offset * 5 + HEART_IMG.get_size()[0] * 2 + i * (self.offset + self.tower_size), self.tower_size, self.tower_size) for i, tower in enumerate(self.game.available_towers)]
         
         self.next_wave_rect = None
         self.tower = None
@@ -38,14 +37,33 @@ class UI:
         self.next_wave_btn_changed = True
 
     def update(self):
-        if (self.lives != self.game.lives or self.protein != self.game.protein or self.next_wave_btn_changed or self.wave != self.game.wave):
-            self.next_wave_btn_changed = False
-            self.wave = self.game.wave
+        ret = True
+        if self.lives != self.game.lives:
             self.lives = self.game.lives
+            ret = False
+
+        if self.protein != self.game.protein:
             self.protein = self.game.protein
-            self.ui = self.get_ui()
-            
-        if not self.game.in_a_wave and self.wave > 0:
+            ret = False
+
+        if self.next_wave_btn_changed:
+            self.next_wave_btn_changed = False
+            ret = False
+
+        if self.game.in_a_wave:
+            if self.wave != self.game.wave:
+                self.wave = self.game.wave
+                ret = False
+
+        else:
+            ret = False
+
+        if ret:
+            return
+
+        self.ui = self.get_ui()
+
+        if not self.game.in_a_wave and self.game.wave > 0:
             self.update_timer()
 
     def select_tower(self, x, y):
@@ -63,37 +81,37 @@ class UI:
         size = HEART_IMG.get_size()[0]
         font = pg.font.Font(FONT, size * 2)
         
-        ui = pg.Surface((self.width, self.game.get_size()[1] - 2 * self.offset))
-        ui.fill(DARK_GREY)
-        
         # Draws waves, lives, protein text
         waves_text = font.render("Wave {}/{}".format(self.wave + 1, self.max_wave), 1, WHITE)
 
+        self.width = waves_text.get_width() + self.offset * 2
+        ui = pg.Surface((waves_text.get_width() + self.offset * 2, self.game.get_size()[1] - 2 * self.offset))
+        ui.fill(DARK_GREY)
+
         ui.blit(waves_text, (self.offset, self.offset))
         ui.blit(HEART_IMG, (self.offset, self.offset * 4 + size))
-        ui.blit(PROTEIN_IMG, (self.offset, self.offset * 5 + size * 2))
-
         lives_text = font.render(str(self.game.lives), 1, WHITE)
         lives_text = pg.transform.scale(lives_text,
                                         (round(lives_text.get_size()[0] * size / lives_text.get_size()[1]), size))
         ui.blit(lives_text, (self.offset * 2 + size, self.offset * 4 + size))
 
+        ui.blit(PROTEIN_IMG, (self.offset * 3 + size + lives_text.get_width(), self.offset * 4 + size))
         protein_text = font.render(str(self.game.protein), 1, WHITE)
         protein_text = pg.transform.scale(protein_text,
                                           (round(protein_text.get_size()[0] * size / protein_text.get_size()[1]), size))
-        ui.blit(protein_text, (self.offset * 2 + size, self.offset * 5 + size * 2))
+        ui.blit(protein_text, (self.offset * 4 + size * 2 + lives_text.get_width(), self.offset * 4 + size))
 
         if self.tower == None:
             # Draws towers
             for i, tower in enumerate(self.game.available_towers):
                 tower_img = pg.transform.scale(TOWER_DATA[tower]["stages"][0]["image"], self.tower_rects[i].size)
-                if (self.game.protein < TOWER_DATA[tower]["stages"][0]["upgrade_cost"]):
+                if (self.game.protein < round(TOWER_DATA[tower]["stages"][0]["upgrade_cost"] * (1 + self.game.difficulty * 0.25))):
                     tower_img.fill(HALF_RED, None, pg.BLEND_RGBA_MULT)
                 ui.blit(tower_img, self.tower_rects[i])
                 temp_rect = self.tower_rects[i].copy()
                 temp_rect.x += self.tower_size + self.offset
                 ui.blit(PROTEIN_IMG, temp_rect)
-                cost_text = font.render(str(TOWER_DATA[tower]["stages"][0]["upgrade_cost"]), 1, WHITE)
+                cost_text = font.render(str(round(TOWER_DATA[tower]["stages"][0]["upgrade_cost"] * (1 + self.game.difficulty * 0.25))), 1, WHITE)
                 temp_rect.y += size + self.offset
                 ui.blit(cost_text, temp_rect)
 
@@ -117,31 +135,30 @@ class UI:
 
             refund = 0
             for stage in range(self.tower.stage + 1):
-                refund += round(tower_dat["stages"][stage]["upgrade_cost"] / 2)
+                refund += round(tower_dat["stages"][stage]["upgrade_cost"] * (1 + self.game.difficulty * 0.25) / 2)
             sell_button, self.sell_rect = self.make_button("Sell: " + str(refund), True)
             self.sell_rect.bottom = SCREEN_HEIGHT - MENU_OFFSET * 4 - self.sell_rect.height
             ui.blit(sell_button, self.sell_rect)
 
             if self.tower.stage < 2:
-                upgrade_cost = tower_dat["stages"][self.tower.stage + 1]["upgrade_cost"]
+                upgrade_cost = round(tower_dat["stages"][self.tower.stage + 1]["upgrade_cost"] * (1 + self.game.difficulty * 0.25))
                 upgrade_button, self.upgrade_rect = self.make_button("Upgrade: " + str(upgrade_cost), self.game.protein >= upgrade_cost)
                 self.upgrade_rect.bottom = SCREEN_HEIGHT - MENU_OFFSET * 5 - self.sell_rect.height * 2
                 ui.blit(upgrade_button, self.upgrade_rect)
         
         text = "Next Wave"
-        if self.wave == 0:
+        if self.game.wave == 0:
             text = "Start Wave"
 
         next_wave_button, self.next_wave_rect = self.make_button(text, self.next_wave_btn_enabled)
         self.next_wave_rect.bottom = SCREEN_HEIGHT - MENU_OFFSET * 3
         ui.blit(next_wave_button, self.next_wave_rect)
-
         return ui
 
     def make_button(self, string, enabled):
         font = pg.font.Font(FONT, int(HEART_IMG.get_size()[0] * 1.3))
         text = font.render(string, 1, WHITE)
-        btn = pg.transform.scale(LEVEL_BUTTON_IMG, (self.width - MENU_OFFSET * 2,
+        btn = pg.transform.scale(LEVEL_BUTTON_IMG, (self.width - self.offset * 2,
                                                               text.get_height())).copy().convert_alpha()
         btn.blit(text, text.get_rect(center=btn.get_rect().center))
 
@@ -154,7 +171,7 @@ class UI:
         return btn, rect
 
     def update_timer(self):
-        timer_width = (self.width - 10) * (WAVE_DELAY * 1000 - self.game.time_passed) // (WAVE_DELAY * 1000)
+        timer_width = (self.width - MENU_OFFSET * 2) * (WAVE_DELAY * 1000 - self.game.time_passed) // (WAVE_DELAY * 1000)
         timer_height = 8
         pg.draw.rect(self.ui, DARK_GREY,
                      pg.Rect(10, self.next_wave_rect.y - timer_height, self.width - 10, timer_height))

--- a/data/game_misc.py
+++ b/data/game_misc.py
@@ -82,7 +82,7 @@ class UI:
         font = pg.font.Font(FONT, size * 2)
         
         # Draws waves, lives, protein text
-        waves_text = font.render("Wave {}/{}".format(self.wave + 1, self.max_wave), 1, WHITE)
+        waves_text = font.render("Wave {}/{}".format(min(self.wave + 1, self.max_wave), self.max_wave), 1, WHITE)
 
         self.width = waves_text.get_width() + self.offset * 2
         ui = pg.Surface((waves_text.get_width() + self.offset * 2, self.game.get_size()[1] - 2 * self.offset))

--- a/data/levels/level00.json
+++ b/data/levels/level00.json
@@ -62,7 +62,7 @@
                     "enemy_type": "common_cold",
                     "enemy_count": 20,
                     "spawn_delay": 3,
-                    "spawn_rate": 0.4
+                    "spawn_rate": 0.2
                 }
             ],
             [
@@ -80,7 +80,7 @@
                     "enemy_type": "common_cold",
                     "enemy_count": 30,
                     "spawn_delay": 4,
-                    "spawn_rate": 0.3
+                    "spawn_rate": 0.2
                 },
                 {
                     "start": 0,
@@ -105,50 +105,292 @@
                 {
                     "start": 0,
                     "enemy_type": "common_cold",
-                    "enemy_count": 20,
-                    "spawn_delay": 3,
+                    "enemy_count": 10,
+                    "spawn_delay": 0.1,
+                    "spawn_rate": 0.4
+                }
+            ],
+            [
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 15,
+                    "spawn_delay": 0.1,
+                    "spawn_rate": 0.4
+                }
+            ],
+            [
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 15,
+                    "spawn_delay": 0.1,
                     "spawn_rate": 0.3
                 }
             ],
             [
                 {
                     "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 15,
+                    "spawn_delay": 0.1,
+                    "spawn_rate": 0.2
+                }
+            ],
+            [
+                {
+                    "start": 0,
+                    "enemy_type": "hepatitis_a",
+                    "enemy_count": 5,
+                    "spawn_delay": 0.2,
+                    "spawn_rate": 0.5
+                }
+            ],
+            [
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 15,
+                    "spawn_delay": 0.1,
+                    "spawn_rate": 0.15
+                }
+            ],
+            [
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 10,
+                    "spawn_delay": 0.1,
+                    "spawn_rate": 0.15
+                },
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 10,
+                    "spawn_delay": 1.8,
+                    "spawn_rate": 0.1
+                }
+            ],
+            [
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 10,
+                    "spawn_delay": 0.1,
+                    "spawn_rate": 0.15
+                },
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 10,
+                    "spawn_delay": 1.8,
+                    "spawn_rate": 0.1
+                }
+            ],
+            [
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 10,
+                    "spawn_delay": 0.1,
+                    "spawn_rate": 0.15
+                },
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 10,
+                    "spawn_delay": 1.8,
+                    "spawn_rate": 0.1
+                }
+            ],
+            [
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 15,
+                    "spawn_delay": 1.5,
+                    "spawn_rate": 0.3
+                },
+                {
+                    "start": 0,
+                    "enemy_type": "hepatitis_a",
+                    "enemy_count": 5,
+                    "spawn_delay": 0.2,
+                    "spawn_rate": 0.6
+                }
+            ],
+            [
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 18,
+                    "spawn_delay": 1,
+                    "spawn_rate": 0.3
+                },
+                {
+                    "start": 0,
+                    "enemy_type": "hepatitis_a",
+                    "enemy_count": 6,
+                    "spawn_delay": 0.2,
+                    "spawn_rate": 0.6
+                }
+            ],
+            [
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 20,
+                    "spawn_delay": 1.5,
+                    "spawn_rate": 0.3
+                },
+                {
+                    "start": 0,
                     "enemy_type": "hepatitis_a",
                     "enemy_count": 8,
-                    "spawn_delay": 3,
+                    "spawn_delay": 0.2,
+                    "spawn_rate": 0.6
+                }
+            ],
+            [
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 20,
+                    "spawn_delay": 2.5,
+                    "spawn_rate": 0.2
+                },
+                {
+                    "start": 0,
+                    "enemy_type": "hepatitis_a",
+                    "enemy_count": 10,
+                    "spawn_delay": 0.2,
                     "spawn_rate": 0.4
+                }
+            ],
+            [
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 25,
+                    "spawn_delay": 2.5,
+                    "spawn_rate": 0.15
+                },
+                {
+                    "start": 0,
+                    "enemy_type": "hepatitis_a",
+                    "enemy_count": 12,
+                    "spawn_delay": 0.2,
+                    "spawn_rate": 0.4
+                }
+            ],
+            [
+                {
+                    "start": 0,
+                    "enemy_type": "hepatitis_a",
+                    "enemy_count": 10,
+                    "spawn_delay": 0.2,
+                    "spawn_rate": 0.4
+                },
+                {
+                    "start": 0,
+                    "enemy_type": "hepatitis_a",
+                    "enemy_count": 10,
+                    "spawn_delay": 0.4,
+                    "spawn_rate": 0.4
+                }
+            ],
+            [
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 30,
+                    "spawn_delay": 2.5,
+                    "spawn_rate": 0.15
+                },
+                {
+                    "start": 0,
+                    "enemy_type": "hepatitis_a",
+                    "enemy_count": 15,
+                    "spawn_delay": 0.2,
+                    "spawn_rate": 0.35
+                }
+            ],
+            [
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 20,
+                    "spawn_delay": 2.5,
+                    "spawn_rate": 0.1
+                },
+                {
+                    "start": 0,
+                    "enemy_type": "hepatitis_a",
+                    "enemy_count": 15,
+                    "spawn_delay": 0.2,
+                    "spawn_rate": 0.3
+                }
+            ],
+            [
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 30,
+                    "spawn_delay": 2.5,
+                    "spawn_rate": 0.1
+                },
+                {
+                    "start": 0,
+                    "enemy_type": "hepatitis_a",
+                    "enemy_count": 15,
+                    "spawn_delay": 0.2,
+                    "spawn_rate": 0.3
+                }
+            ],
+            [
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 30,
+                    "spawn_delay": 2.5,
+                    "spawn_rate": 0.1
+                },
+                {
+                    "start": 0,
+                    "enemy_type": "hepatitis_a",
+                    "enemy_count": 15,
+                    "spawn_delay": 0.2,
+                    "spawn_rate": 0.3
+                }
+            ],
+            [
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 20,
+                    "spawn_delay": 0.05,
+                    "spawn_rate": 0.05
                 },
                 {
                     "start": 0,
                     "enemy_type": "common_cold",
                     "enemy_count": 20,
-                    "spawn_delay": 3,
-                    "spawn_rate": 0.4
-                }
-            ],
-            [
-                {
-                    "start": 0,
-                    "enemy_type": "hepatitis_a",
-                    "enemy_count": 15,
-                    "spawn_delay": 3,
-                    "spawn_rate": 0.5
+                    "spawn_delay": 0.05,
+                    "spawn_rate": 0.05
                 },
                 {
                     "start": 0,
                     "enemy_type": "common_cold",
-                    "enemy_count": 30,
-                    "spawn_delay": 4,
-                    "spawn_rate": 0.2
-                }
-            ],
-            [
+                    "enemy_count": 20,
+                    "spawn_delay": 0.05,
+                    "spawn_rate": 0.05
+                },
                 {
                     "start": 0,
-                    "enemy_type": "hepatitis_a",
-                    "enemy_count": 40,
-                    "spawn_delay": 4,
-                    "spawn_rate": 0.2
+                    "enemy_type": "common_cold",
+                    "enemy_count": 20,
+                    "spawn_delay": 0.05,
+                    "spawn_rate": 0.05
                 }
             ]
         ],
@@ -221,14 +463,14 @@
                     "enemy_type": "common_cold",
                     "enemy_count": 20,
                     "spawn_delay": 2.5,
-                    "spawn_rate": 0.1
+                    "spawn_rate": 0.2
                 },
                 {
                     "start": 0,
                     "enemy_type": "hepatitis_a",
                     "enemy_count": 20,
                     "spawn_delay": 3,
-                    "spawn_rate": 0.1
+                    "spawn_rate": 0.2
                 },
                 {
                     "start": 0,

--- a/data/levels/level00.json
+++ b/data/levels/level00.json
@@ -42,7 +42,24 @@
             [],
             [
                 "Nice one! But an even more difficult challenge awaits!"
-            ]
+            ],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            []
         ],
         [
             [

--- a/data/save.json
+++ b/data/save.json
@@ -2,27 +2,35 @@
     "levels": [
         [
             true,
+            true,
+            true
+        ],
+        [
+            true,
             false,
             false
         ]
     ],
-    "music_vol": 0.3,
-    "sfx_vol": 0.312,
+    "music_vol": 0.0,
+    "sfx_vol": 0.0,
     "width": 1366,
     "fullscreen": false,
     "skip_text": true,
-    "max_dna": 0,
+    "max_dna": 119,
     "used_dna": 0,
     "highscores": [
+        119,
         0
     ],
     "owned_towers": [
+        "t_cell",
         "m_cell",
         "mast_cell",
         "plasma_cell"
     ],
     "seen_enemies": [
-        "common_cold"
+        "common_cold",
+        "hepatitis_a"
     ],
     "game_attrs": {
         "lives": {
@@ -33,7 +41,7 @@
             "description": "The number of lives you start with on each level."
         },
         "starting_protein": {
-            "value": 30,
+            "value": 50,
             "increment": 5,
             "upgrade_cost": 85,
             "cost_increment": 10,


### PR DESCRIPTION
This also adds several other changes:
- Fixes issue with UI when there are more than 9 waves
- Buffs enemy hp as a level progresses
- Buffs enemy hp based on difficulty
- Increments tower cost based on difficulty
- Fixes wave number issues
- Changes health bar to a logarithmic scale

Note: the level isn't done yet, but I want to integrate the rest of these changes already.