### PR TITLE
Rebalanced early levels

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -12,8 +12,8 @@
     "coronavirus": {
         "explode_on_death": false,
         "flying": false,
-        "hp": 1000,
-        "protein": 10,
+        "hp": 750,
+        "protein": 9,
         "shield": false,
         "mutate": false,
         "speed": 80,

--- a/data/enemies.py
+++ b/data/enemies.py
@@ -183,6 +183,7 @@ class Enemy(pg.sprite.Sprite):
 
         if (len(self.path) == 0):
             self.game.lives = max(self.game.lives - 1, 0)
+            self.game.ui.generate_header_wrapper()
             self.game.protein += self.dropped_protein   # TODO: Remove this dev feature
                                                         # (enemies shouldn't drop protein if they reach the goal)
             

--- a/data/game.py
+++ b/data/game.py
@@ -29,7 +29,7 @@ def collide_with_walls(sprite, group, dir):
             sprite.vel.y = 0
             sprite.hit_rect.centery = sprite.pos.y
 
-skip_to_wave = 0   # TODO: Remove this dev option
+skip_to_wave = 9   # TODO: Remove this dev option
                     # Change this to change which wave you start on. You'll get all the protein from the previous waves.
                     # Indexing starts at 0 and the wave this is set to is inclusive.
                     # i.e. if the value is set to 15, the game will start at wave 16 (when counting from 1).
@@ -243,7 +243,6 @@ class Game(Display):
                     elif len(self.enemies) == 0:
                         pg.event.post(self.game_done_event)
 
-
     def current_wave_done(self):
         for start in self.starts:
             if not start.is_done_spawning():
@@ -304,7 +303,7 @@ class Game(Display):
                 self.new_enemy_box.show_new_enemy(start.enemy_type)
 
     def draw(self):
-        temp_surf = pg.Surface((1280, 720))
+        temp_surf = pg.Surface((self.map_rect.w, self.map_rect.h))
 
         temp_surf.blit(self.map_img, self.map_rect)
 

--- a/data/game.py
+++ b/data/game.py
@@ -29,7 +29,7 @@ def collide_with_walls(sprite, group, dir):
             sprite.vel.y = 0
             sprite.hit_rect.centery = sprite.pos.y
 
-skip_to_wave = 9   # TODO: Remove this dev option
+skip_to_wave = 0   # TODO: Remove this dev option
                     # Change this to change which wave you start on. You'll get all the protein from the previous waves.
                     # Indexing starts at 0 and the wave this is set to is inclusive.
                     # i.e. if the value is set to 15, the game will start at wave 16 (when counting from 1).

--- a/data/game_misc.py
+++ b/data/game_misc.py
@@ -84,11 +84,11 @@ class UI:
     def generate_header(self):
         # Draws waves, lives, protein text
         waves_text = self.font.render("Wave {}/{}".format(min(self.wave + 1, self.max_wave), self.max_wave), 1, WHITE)
-
         width = max(waves_text.get_width() + self.offset * 2, 225)
         if width != self.width:
             self.width = width
             self.regen_surfs()
+            self.generate_body()
 
         self.header.fill(DARK_GREY)
         self.header.blit(waves_text, waves_text.get_rect(midtop=(self.width / 2, 0)))

--- a/data/levels/level01.json
+++ b/data/levels/level01.json
@@ -2,7 +2,7 @@
     "description": ["The second mission of the game. Expect a step up from the tutorial, but nothing too daunting.", "", ""],
     "ratings": [0, 1, 1],
     "body_part": 1,
-    "protein_goal": [2000, 10, 10],
+    "protein_goal": [3000, 10, 10],
     "texts": [
         {
             "0":    [
@@ -92,7 +92,7 @@
                     "enemy_type": "polio",
                     "enemy_count": 40,
                     "spawn_delay": 3,
-                    "spawn_rate": 0.4
+                    "spawn_rate": 0.3
                 }
             ],
             [
@@ -163,24 +163,24 @@
                 {
                     "start": 0,
                     "enemy_type": "coronavirus",
-                    "enemy_count": 40,
+                    "enemy_count": 7,
                     "spawn_delay": 3,
-                    "spawn_rate": 0.35
+                    "spawn_rate": 1.5
                 }
             ],
             [
                 {
                     "start": 0,
                     "enemy_type": "coronavirus",
-                    "enemy_count": 40,
+                    "enemy_count": 10,
+                    "spawn_delay": 3,
+                    "spawn_rate": 1.2
+                },
+                {
+                    "start": 0,
+                    "enemy_type": "common_cold",
+                    "enemy_count": 100,
                     "spawn_delay": 5,
-                    "spawn_rate": 0.25
-                },
-                {
-                    "start": 0,
-                    "enemy_type": "common_cold",
-                    "enemy_count": 100,
-                    "spawn_delay": 3,
                     "spawn_rate": 0.1
                 }
             ],
@@ -188,7 +188,7 @@
                 {
                     "start": 0,
                     "enemy_type": "coronavirus",
-                    "enemy_count": 50,
+                    "enemy_count": 5,
                     "spawn_delay": 3,
                     "spawn_rate": 0.2
                 },
@@ -198,15 +198,22 @@
                     "enemy_count": 100,
                     "spawn_delay": 3,
                     "spawn_rate": 0.1
+                },
+                {
+                    "start": 0,
+                    "enemy_type": "coronavirus",
+                    "enemy_count": 5,
+                    "spawn_delay": 13,
+                    "spawn_rate": 0.2
                 }
             ],
             [
                 {
                     "start": 0,
                     "enemy_type": "coronavirus",
-                    "enemy_count": 50,
+                    "enemy_count": 10,
                     "spawn_delay": 3,
-                    "spawn_rate": 0.2
+                    "spawn_rate": 0.8
                 },
                 {
                     "start": 0,
@@ -234,18 +241,18 @@
                 {
                     "start": 0,
                     "enemy_type": "coronavirus",
-                    "enemy_count": 60,
+                    "enemy_count": 10,
                     "spawn_delay": 10,
-                    "spawn_rate": 0.05
+                    "spawn_rate": 0.1
                 }
             ],
             [
                 {
                     "start": 0,
                     "enemy_type": "coronavirus",
-                    "enemy_count": 60,
+                    "enemy_count": 10,
                     "spawn_delay": 3,
-                    "spawn_rate": 0.2
+                    "spawn_rate": 0.8
                 },
                 {
                     "start": 0,
@@ -259,9 +266,9 @@
                 {
                     "start": 0,
                     "enemy_type": "coronavirus",
-                    "enemy_count": 60,
+                    "enemy_count": 10,
                     "spawn_delay": 3,
-                    "spawn_rate": 0.2
+                    "spawn_rate": 1
                 },
                 {
                     "start": 0,
@@ -291,9 +298,9 @@
                 {
                     "start": 0,
                     "enemy_type": "coronavirus",
-                    "enemy_count": 50,
+                    "enemy_count": 10,
                     "spawn_delay": 3,
-                    "spawn_rate": 0.2
+                    "spawn_rate": 0.5
                 },
                 {
                     "start": 0,
@@ -312,8 +319,8 @@
                 {
                     "start": 0,
                     "enemy_type": "coronavirus",
-                    "enemy_count": 30,
-                    "spawn_delay": 15,
+                    "enemy_count": 5,
+                    "spawn_delay": 13,
                     "spawn_rate": 0.1
                 }
             ],
@@ -321,9 +328,9 @@
                 {
                     "start": 0,
                     "enemy_type": "coronavirus",
-                    "enemy_count": 60,
+                    "enemy_count": 12,
                     "spawn_delay": 3,
-                    "spawn_rate": 0.2
+                    "spawn_rate": 1
                 },
                 {
                     "start": 0,
@@ -342,9 +349,9 @@
                 {
                     "start": 0,
                     "enemy_type": "coronavirus",
-                    "enemy_count": 40,
+                    "enemy_count": 12,
                     "spawn_delay": 24,
-                    "spawn_rate": 0.2
+                    "spawn_rate": 1
                 },
                 {
                     "start": 0,

--- a/data/levels/level02.json
+++ b/data/levels/level02.json
@@ -2,7 +2,7 @@
     "description": ["This map features multiple exit routes. Intelligence reports recommend deploying shieldbreaking cells as well.", "", ""],
     "ratings": [0, 1, 1],
     "body_part": 2,
-    "protein_goal": [1000, 10, 10],
+    "protein_goal": [1800, 10, 10],
     "texts": [
         {
             "0":    [
@@ -75,9 +75,9 @@
                 {
                     "start": 0,
                     "enemy_type": "coronavirus",
-                    "enemy_count": 30,
+                    "enemy_count": 5,
                     "spawn_delay": 2,
-                    "spawn_rate": 0.5
+                    "spawn_rate": 1.2
                 }
             ],
             [
@@ -123,18 +123,18 @@
                 {
                     "start": 0,
                     "enemy_type": "coronavirus",
-                    "enemy_count": 30,
+                    "enemy_count": 6,
                     "spawn_delay": 2,
-                    "spawn_rate": 0.4
+                    "spawn_rate": 1
                 }
             ],
             [
                 {
                     "start": 0,
                     "enemy_type": "coronavirus",
-                    "enemy_count": 60,
+                    "enemy_count": 10,
                     "spawn_delay": 2,
-                    "spawn_rate": 0.25
+                    "spawn_rate": 0.8
                 }
             ],
             [
@@ -148,9 +148,9 @@
                 {
                     "start": 0,
                     "enemy_type": "coronavirus",
-                    "enemy_count": 40,
+                    "enemy_count": 7,
                     "spawn_delay": 3,
-                    "spawn_rate": 0.4
+                    "spawn_rate": 1
                 },
                 {
                     "start": 0,
@@ -228,9 +228,9 @@
                 {
                     "start": 0,
                     "enemy_type": "coronavirus",
-                    "enemy_count": 30,
+                    "enemy_count": 8,
                     "spawn_delay": 2,
-                    "spawn_rate": 0.15
+                    "spawn_rate": 0.5
                 }
             ],
             [
@@ -322,16 +322,16 @@
                 {
                     "start": 0,
                     "enemy_type": "coronavirus",
-                    "enemy_count": 40,
-                    "spawn_delay": 4,
-                    "spawn_rate": 0.25
+                    "enemy_count": 10,
+                    "spawn_delay": 2,
+                    "spawn_rate": 0.8
                 },
                 {
                     "start": 0,
                     "enemy_type": "coronavirus",
-                    "enemy_count": 40,
-                    "spawn_delay": 17,
-                    "spawn_rate": 0.05
+                    "enemy_count": 7,
+                    "spawn_delay": 15,
+                    "spawn_rate": 0.1
                 }
             ]
         ],

--- a/data/settings.py
+++ b/data/settings.py
@@ -302,7 +302,7 @@ HEART_MONITOR_FLATLINE_IMG = pg.image.load(path.join(GAME_STOP_IMG_FOLDER, "hear
 # load fonts path
 FONT = path.join(FONTS_FOLDER, "mini_pixel-7.ttf")
 
-WAVE_DELAY = 9999 # TODO: Change this dev feature back.
+WAVE_DELAY = 10 # TODO: Change this dev feature back.
 EXPLOSION_TIME = 0.25
 REFUND_AMOUNT = 0.5
 

--- a/data/settings.py
+++ b/data/settings.py
@@ -302,7 +302,7 @@ HEART_MONITOR_FLATLINE_IMG = pg.image.load(path.join(GAME_STOP_IMG_FOLDER, "hear
 # load fonts path
 FONT = path.join(FONTS_FOLDER, "mini_pixel-7.ttf")
 
-WAVE_DELAY = 5 # TODO: Change this dev feature back.
+WAVE_DELAY = 9999 # TODO: Change this dev feature back.
 EXPLOSION_TIME = 0.25
 REFUND_AMOUNT = 0.5
 


### PR DESCRIPTION
Rebalanced Mild Esophagus and Trachea to take into account the new Coronavirus buffs (and the general buff to the protein dropped by viruses). 

Also fixes #277, #278, and #279, and reduced coronavirus HP to 750.
